### PR TITLE
reimplement live button as video.js Button component

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -58,45 +58,45 @@ $colorButtonOutAir:gray;
         @include no-seleccionable;
         min-width: 50px;
 
-        & .vjs-live-label{
-          width: 100%;
-          display: block;
-          font-weight: bold;
-          //font-size: 14px;
+        font-weight: bold;
+        //font-size: 14px;
 
-          position: relative;
-          //bottom: calc(-50% + 5px);
-          transform: translateY(-0.5em);
-          top: 50%;
-          color: #8c8b8b;
-          //border-radius: 3px;
-          //background-color: $colorButtonOutAir;
-          &.onair {
-            color:#fff;
-            //background-color: $colorButtonOnAir;
-            & .liveCircle:after{
-              background: $colorButtonOnAir;
-            }
-
+        position: relative;
+        //bottom: calc(-50% + 5px);
+        color: #8c8b8b;
+        //border-radius: 3px;
+        //background-color: $colorButtonOutAir;
+        &.onair {
+          color:#fff;
+          //background-color: $colorButtonOnAir;
+          & .liveCircle:after{
+            background: $colorButtonOnAir;
+          }
+          &:focus .liveCircle:after {
+            box-shadow: 0 0 1em $colorButtonOnAir;
           }
 
-          & .liveText{
-            margin-left: 1.5em;
-          }
+        }
 
-          & .liveCircle:after {
-            content: '';
-            position: absolute;
-            width: .9em;
-            height: .9em;
-            border-radius: 50%;
-            background: $colorButtonOutAir;
-            left: .5em;
-          }
+        & .liveText{
+          margin-left: 1.5em;
+        }
 
-          &:hover{
-            cursor: pointer;
-          }
+        & .liveCircle:after {
+          content: '';
+          position: absolute;
+          width: .9em;
+          height: .9em;
+          border-radius: 50%;
+          background: $colorButtonOutAir;
+          left: .5em;
+        }
+        &:focus .liveCircle:after {
+          box-shadow: 0 0 1em $colorButtonOutAir;
+        }
+
+        &:hover{
+          cursor: pointer;
         }
       }
 


### PR DESCRIPTION
Reimplements the live button as a video.js [Button component](https://docs.videojs.com/button). This enables it to handle tap events on touch devices and also removes the need for IE-specific attachEvent code.

Note: This change also removes the `vjs-live-label` class because the `<button>` element is placed as a direct child of the control bar div (like other Button components) so there's no need for a wrapper. This is likely to break existing dvr-specific skins.